### PR TITLE
Project status auto updates to archived when it has an archive created

### DIFF
--- a/app/controllers/archives_controller.rb
+++ b/app/controllers/archives_controller.rb
@@ -4,9 +4,11 @@ class ArchivesController < ApplicationController
   end
 
   def create
-    archive = find_project.archives.new(archive_params)
+    project = find_project
+    archive = project.archives.new(archive_params)
     if archive.save
-      redirect_to archive.project
+      project.archived!
+      redirect_to project
     else
       @archive = archive
       render :new

--- a/spec/features/user_creates_archive_for_project_spec.rb
+++ b/spec/features/user_creates_archive_for_project_spec.rb
@@ -12,6 +12,7 @@ feature 'user creates project archive' do
     fill_in 'archive_notes', with: 'yada yada'
     click_on('Add Archive')
 
+    expect(page).to have_content('Status: archived')
     expect(page).to have_content('drive_number')
     click_on('drive_number')
     expect(page).to have_content('project_name')


### PR DESCRIPTION
Add functionality for Project to auto change it's status to 'archived' when it has an archive relationship created. This saves the user from having to update the project status on their own (likely forgetting to do so). The most common use case is for a project to be changed to archived once it has an archive relationship. The user can still change the project status back to something other than archived for fringe/exception cases. 
